### PR TITLE
[BD-26] Fix tests redirect to the sequence legacyWebUrl

### DIFF
--- a/src/courseware/data/__factories__/courseMetadata.factory.js
+++ b/src/courseware/data/__factories__/courseMetadata.factory.js
@@ -56,4 +56,5 @@ Factory.define('courseMetadata')
     verification_status: 'none',
     linkedin_add_to_profile_url: null,
     related_programs: null,
+    is_mfe_special_exams_enabled: false,
   });


### PR DESCRIPTION
[OeX_Proctoring-196](https://youtrack.raccoongang.com/issue/OeX_Proctoring-196) Fix tests redirect to the sequence legacyWebUrl
- added `is_mfe_special_exams_enabled` to `courseMetadata.factory.js `