### PR TITLE
Fix not waiting for sequence to load before checking for proctored exams flag

### DIFF
--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -178,8 +178,8 @@ class CoursewareContainer extends Component {
     // Check special exam redirect:
     //    /course/:courseId/:sequenceId(/:unitId) -> :legacyWebUrl
     // because special exams are currently still served in the legacy LMS frontend.
-    const isDisabledProctoredExams = specialExamsEnabledWaffleFlag && sequence.isProctored
-      && !proctoredExamsEnabledWaffleFlag;
+    const isDisabledProctoredExams = specialExamsEnabledWaffleFlag && sequenceStatus === 'loaded'
+      && sequence.isProctored && !proctoredExamsEnabledWaffleFlag;
     if (!specialExamsEnabledWaffleFlag || isDisabledProctoredExams) {
       checkSpecialExamRedirect(sequenceStatus, sequence);
     }


### PR DESCRIPTION
Fixed a bug where a page would load with error because we try to check if proctored exams are enabled before sequence is loaded