### PR TITLE
feat: [AsPu-665] Certificate status callout box

### DIFF
--- a/src/course-home/progress-tab/ProgressTab.test.jsx
+++ b/src/course-home/progress-tab/ProgressTab.test.jsx
@@ -5,6 +5,7 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { breakpoints } from '@edx/paragon';
 import MockAdapter from 'axios-mock-adapter';
+import { within } from '@testing-library/react';
 
 import {
   fireEvent, initializeMockApp, logUnhandledRequests, render, screen, act,
@@ -1112,6 +1113,11 @@ describe('Progress Tab', () => {
           linkType: 'button',
           pageName: 'progress',
         });
+
+        const certificateStatusComponent = screen.queryByTestId('certificate-status-component');
+        expect(certificateStatusComponent).toBeInTheDocument();
+        const headerElement = within(certificateStatusComponent).getByRole('heading', { level: 2 });
+        expect(headerElement).toBeInTheDocument();
       });
 
       it('Displays nothing if audit only', async () => {

--- a/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
+++ b/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
@@ -236,7 +236,7 @@ const CertificateStatus = ({ intl }) => {
   return (
     <section data-testid="certificate-status-component" className="text-dark-700 mb-4">
       <Card className="bg-light-200 raised-card">
-        <Card.Header title={header} />
+        <Card.Header title={<h2>{header}</h2>} />
         <Card.Section className="small text-gray-700">
           {body}
         </Card.Section>


### PR DESCRIPTION
Certificate status Callout box - Certificate Status should be marked up as a heading level 2.
![image](https://github.com/user-attachments/assets/ae581c74-fcc3-41d9-837b-26be43fbb7e9)

[YouTrack](https://youtrack.raccoongang.com/issue/AsPu-665/Certificate-Status-Callout-Box-and-Glossary-Terms)