### PR TITLE
feat: [ENG-63] dark theme for course-outline iframe text

### DIFF
--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -9,6 +9,10 @@ and this project adheres to customized Semantic Versioning e.g.: `teak-rg.1`
 [Unreleased]
 ************
 
+Added:
+======
+* Mirror the active dark theme inside the course-outline welcome/handouts iframe via the shared ``theme-variant`` cookie (ENG-63)
+
 [release/teak-rg.3] - 2026-02-18
 ********************************
 

--- a/src/course-home/outline-tab/LmsHtmlFragment.jsx
+++ b/src/course-home/outline-tab/LmsHtmlFragment.jsx
@@ -11,13 +11,23 @@ const LmsHtmlFragment = ({
   ...rest
 }) => {
   const direction = document.documentElement?.getAttribute('dir') || 'ltr';
-  const brandOverride = getConfig().PARAGON_THEME_URLS?.variants?.light?.urls?.brandOverride;
+  // Mirror the active dark theme inside the fragment iframe. The iframe loads the
+  // legacy LMS CSS (lms-main.css), which already contains the compiled
+  // `html[data-theme="dark"]` rules, but the iframe's <html> never gets the
+  // attribute — so authored welcome/handouts text keeps its light-theme color
+  // (#313131) and is invisible on the dark page. Read the shared `theme-variant`
+  // cookie (canonical signal, set on the parent domain by the header toggle) and
+  // stamp data-theme + load the matching brand variables, exactly as the legacy
+  // head-extra.html does for server-rendered pages.
+  const themeVariant = (document.cookie.match(/(?:^|;\s*)theme-variant=(dark|light)\b/) || [])[1] || '';
+  const isDark = themeVariant === 'dark';
+  const brandOverride = getConfig().PARAGON_THEME_URLS?.variants?.[isDark ? 'dark' : 'light']?.urls?.brandOverride;
   const BrandingFontLoader = footerExports?.services?.BrandingFontLoader;
   const brandLinkTag = brandOverride
     ? `<link rel="stylesheet" href="${brandOverride}">`
     : '';
   const wholePage = `
-    <html dir="${direction}">
+    <html dir="${direction}"${isDark ? ' data-theme="dark"' : ''}>
       <head>
         <base href="${getConfig().LMS_BASE_URL}" target="_parent">
         <link rel="stylesheet" href="/static/${getConfig().LEGACY_THEME_NAME ? `${getConfig().LEGACY_THEME_NAME}/` : ''}css/bootstrap/lms-main.css">


### PR DESCRIPTION
## Description

On the course outline page, the "welcome" message and course handouts are
rendered inside an embedded frame that loads the legacy LMS styles but never
inherited the active theme. In dark mode this left the authored text in its
light-theme color, making it effectively invisible against the dark page. This
change makes that embedded content follow the user's dark theme, so the welcome
message and handouts are readable and visually consistent with the rest of the
course page in dark mode.

## Youtrack

- https://youtrack.raccoongang.com/issue/ENG-63

## Screenshot/Video

| 1 | 2 | 3 |
|--------|--------|--------|
| <img width="3456" height="3166" alt="image" src="https://github.com/user-attachments/assets/4f826bb3-6abb-43a7-818b-e80a45afce8d" /> | <img width="3456" height="5144" alt="image" src="https://github.com/user-attachments/assets/6c68ae18-7bcf-4250-a71e-60f558211ee3" /> | <img width="3456" height="3348" alt="image" src="https://github.com/user-attachments/assets/e73a45d2-fccd-4230-8ab6-af580b4d4702" /> | 

## Testing

**1. Welcome message in dark mode (happy path)**
1. As an enrolled learner with dark mode enabled (the `theme-variant=dark`
   cookie is set), open a course that has an authored welcome message.
2. Go to the course outline (home) page.
3. Expected: the welcome message text is rendered in dark-theme colors and is
   clearly readable against the dark page (not faint/near-invisible).

**2. Course handouts in dark mode**
1. Same dark-mode precondition, in a course that has handouts.
2. View the handouts block on the outline page.
3. Expected: handouts text and links are legible against the dark surface.

**3. Light mode unchanged**
1. With dark mode off (no `theme-variant` cookie, or set to `light`), open the
   course outline.
2. Expected: the welcome message and handouts render in the standard light
   theme — no visual change from before.

**4. Toggle then reload**
1. View the outline in light mode, then switch to dark mode and reload the
   course outline page.
2. Expected: the welcome/handouts content renders dark after reload.

**5. RTL direction preserved**
1. In a right-to-left language, open the outline in dark mode.
2. Expected: text direction stays right-to-left and the dark styling applies
   correctly.
