### PR TITLE
feat: [VERA-6] course-outline iframe branding and dark theme

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,17 +20,3 @@ jobs:
       with:
         name: code-coverage-report
         path: coverage/*.*
-  coverage:
-    runs-on: ubuntu-latest
-    needs: tests
-    steps:
-    - uses: actions/checkout@v5
-    - name: Download code coverage results
-      uses: actions/download-artifact@v5
-      with:
-        pattern: code-coverage-report
-    - name: Upload coverage
-      uses: codecov/codecov-action@v5
-      with:
-        fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}

--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -13,3 +13,7 @@ Added:
 ======
 * Apply branding custom fonts loading for updates block in course outline (TEA-289)
 * Mirror the active dark theme inside the course-outline welcome/handouts iframe via the shared ``theme-variant`` cookie (ENG-63)
+
+Removed:
+========
+* codecov CI action, and the ``coverage`` job left with nothing to do — the fork has no codecov project, so the step failed every run (VERA-6)

--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -1,0 +1,14 @@
+RG Changelog
+############
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
+and this project adheres to customized Semantic Versioning e.g.: `verawood-rg.1`
+
+[Unreleased]
+************
+
+Added:
+======
+* Apply branding custom fonts loading for updates block in course outline (TEA-289)

--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -12,3 +12,4 @@ and this project adheres to customized Semantic Versioning e.g.: `verawood-rg.1`
 Added:
 ======
 * Apply branding custom fonts loading for updates block in course outline (TEA-289)
+* Mirror the active dark theme inside the course-outline welcome/handouts iframe via the shared ``theme-variant`` cookie (ENG-63)

--- a/src/course-home/outline-tab/LmsHtmlFragment.jsx
+++ b/src/course-home/outline-tab/LmsHtmlFragment.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { getConfig } from '@edx/frontend-platform';
+import * as footerExports from '@edx/frontend-component-footer';
 
 const LmsHtmlFragment = ({
   className,
@@ -10,12 +11,18 @@ const LmsHtmlFragment = ({
   ...rest
 }) => {
   const direction = document.documentElement?.getAttribute('dir') || 'ltr';
+  const brandOverride = getConfig().PARAGON_THEME_URLS?.variants?.light?.urls?.brandOverride;
+  const BrandingFontLoader = footerExports?.services?.BrandingFontLoader;
+  const brandLinkTag = brandOverride
+    ? `<link rel="stylesheet" href="${brandOverride}">`
+    : '';
   const wholePage = `
     <html dir="${direction}">
       <head>
         <base href="${getConfig().LMS_BASE_URL}" target="_parent">
         <link rel="stylesheet" href="/static/${getConfig().LEGACY_THEME_NAME ? `${getConfig().LEGACY_THEME_NAME}/` : ''}css/bootstrap/lms-main.css">
         <link rel="stylesheet" type="text/css" href="${getConfig().BASE_URL}/static/LmsHtmlFragment.css">
+        ${brandLinkTag}
       </head>
       <body class="${className}">${html}</body>
       <script>
@@ -47,7 +54,13 @@ const LmsHtmlFragment = ({
   return (
     <iframe
       className="w-100 border-0"
-      onLoad={resetIframeHeight}
+      onLoad={(event) => {
+        resetIframeHeight();
+        const iframeDocument = event.currentTarget?.contentDocument;
+        if (iframeDocument && BrandingFontLoader) {
+          new BrandingFontLoader({ config: getConfig(), target: iframeDocument }).loadScript();
+        }
+      }}
       ref={iframe}
       referrerPolicy="origin"
       scrolling="no"

--- a/src/course-home/outline-tab/LmsHtmlFragment.jsx
+++ b/src/course-home/outline-tab/LmsHtmlFragment.jsx
@@ -11,13 +11,23 @@ const LmsHtmlFragment = ({
   ...rest
 }) => {
   const direction = document.documentElement?.getAttribute('dir') || 'ltr';
-  const brandOverride = getConfig().PARAGON_THEME_URLS?.variants?.light?.urls?.brandOverride;
+  // Mirror the active dark theme inside the fragment iframe. The iframe loads the
+  // legacy LMS CSS (lms-main.css), which already contains the compiled
+  // `html[data-theme="dark"]` rules, but the iframe's <html> never gets the
+  // attribute — so authored welcome/handouts text keeps its light-theme color
+  // (#313131) and is invisible on the dark page. Read the shared `theme-variant`
+  // cookie (canonical signal, set on the parent domain by the header toggle) and
+  // stamp data-theme + load the matching brand variables, exactly as the legacy
+  // head-extra.html does for server-rendered pages.
+  const themeVariant = (document.cookie.match(/(?:^|;\s*)theme-variant=(dark|light)\b/) || [])[1] || '';
+  const isDark = themeVariant === 'dark';
+  const brandOverride = getConfig().PARAGON_THEME_URLS?.variants?.[isDark ? 'dark' : 'light']?.urls?.brandOverride;
   const BrandingFontLoader = footerExports?.services?.BrandingFontLoader;
   const brandLinkTag = brandOverride
     ? `<link rel="stylesheet" href="${brandOverride}">`
     : '';
   const wholePage = `
-    <html dir="${direction}">
+    <html dir="${direction}"${isDark ? ' data-theme="dark"' : ''}>
       <head>
         <base href="${getConfig().LMS_BASE_URL}" target="_parent">
         <link rel="stylesheet" href="/static/${getConfig().LEGACY_THEME_NAME ? `${getConfig().LEGACY_THEME_NAME}/` : ''}css/bootstrap/lms-main.css">


### PR DESCRIPTION
## Description

The "Welcome" message and Course Handouts blocks on the course outline render author-written HTML inside a sandboxed iframe, so they inherit nothing from the surrounding page — not the site's brand fonts, and not the reader's light/dark choice. Welcome text therefore fell back to the browser's default typeface, and in dark mode it stayed near-black on a dark background, effectively unreadable. This change carries the brand fonts and the active theme into that iframe so authored text matches the rest of the outline page.

It also re-establishes the RaccoonGang fork of the Learning MFE on the Verawood release line. Only these two fixes still need to be carried: everything else the teak-rg fork held (the Paragon v23 / design-token migration, the CSS-variable restyle, the deprecated-component swap, the calculator table styles, the @edx/brand override import) is now either shipped by upstream Verawood or obsolete there, so it is deliberately not brought over.

## Youtrack

- https://youtrack.raccoongang.com/issue/VERA-6

## Related PRs / Dependencies

- **RG footer fork, Verawood branches** — `romaniuk/feat/VERA-4/upgrade-footer-to-verawood` and
  `ihor-romaniuk/feat/VERA-2/absorb-brand-footer-styles`. The font half of this PR reaches
  `services.BrandingFontLoader`, which is an **RG-fork-only** export of
  `@edx/frontend-component-footer`. It is imported as a namespace with optional chaining
  precisely so it degrades to a no-op against upstream — so this PR is safe to merge first,
  but custom fonts inside the iframe only start loading once the RG footer is published and
  picked up as a build-time override.
- **tutor-contrib-rg-theme** — supplies the other half of the contract: the legacy
  `html[data-theme="dark"]` rules compiled into `lms-main.css` that this iframe now activates,
  and the MFE `env.config.jsx` bridge that mirrors Paragon's `data-paragon-theme-variant` into
  the shared `theme-variant` cookie. Already in place; no change needed.

## Testing

1. **Brand font in the Welcome block**
   - Preconditions: a course with a "Welcome" / course-update message authored in Studio;
     site config supplying `CUSTOM_FONTS` and/or `GOOGLE_FONTS`; MFE built against the **RG**
     footer fork.
   - Actions: open the course outline as an enrolled learner. Inspect the welcome iframe's
     `<head>` in devtools.
   - Expected: a `<style id="custom-fonts-style">` (and/or the Google Fonts `<link>`) is
     present *inside the iframe document*, and the welcome text renders in the brand face
     rather than the browser default.

2. **Brand stylesheet is linked into the fragment**
   - Preconditions: `PARAGON_THEME_URLS.variants.light.urls.brandOverride` configured.
   - Actions: on the course outline, inspect the welcome iframe's `<head>`.
   - Expected: a `<link rel="stylesheet">` pointing at the light `brandOverride` URL.

3. **Dark mode is mirrored into the iframe**
   - Preconditions: theme mode `both` (toggle available); a course with a welcome message
     and course handouts.
   - Actions: switch the site to dark using the header toggle, then open/reload the course
     outline.
   - Expected: the iframe's `<html>` carries `data-theme="dark"`, the linked `brandOverride`
     is now the **dark** variant, and the authored text is readable against the dark surface
     — no near-black-on-dark. Both the Welcome and Course Handouts fragments behave the same.

4. **Light mode is unchanged**
   - Actions: switch back to light and reload the outline.
   - Expected: no `data-theme` attribute on the iframe `<html>`, the light `brandOverride` is
     linked, and rendering is identical to before this change.

5. **Cross-origin round-trip via the shared cookie**
   - Preconditions: MFE and LMS on different hosts under a shared parent domain
     (e.g. `apps.local.openedx.io` / `local.openedx.io`).
   - Actions: toggle dark on a **server-rendered** LMS page, then navigate to the course
     outline in the MFE.
   - Expected: the outline renders dark and so does the fragment iframe — the `theme-variant`
     cookie is the signal, so no MFE-side toggle is required first. Repeat in the other
     direction (toggle in the MFE header, then load a legacy page).

6. **Graceful degradation against the upstream footer**
   - Preconditions: MFE built with the **upstream** `@edx/frontend-component-footer` (14.9.5),
     which has no `services` export — this is the state on a plain Verawood build today.
   - Actions: open the course outline with devtools console open.
   - Expected: page renders, no console error, no crash. Fonts are simply not injected into
     the iframe; the `data-theme` / `brandOverride` behaviour still works, since that half
     does not depend on the footer.

7. **Regression: no cookie set / malformed cookie**
   - Actions: clear cookies and load the outline; then set `theme-variant=bogus` manually
     and reload.
   - Expected: both cases fall back to light with no `data-theme` attribute; no exception.

8. **Regression: iframe auto-height**
   - Actions: view a long welcome message at desktop and mobile widths, in both themes.
   - Expected: the iframe still resizes to its content (the `ResizeObserver` → `postMessage`
     path is untouched); no clipping and no inner scrollbar.
